### PR TITLE
ACL Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The ACL Package
   * [Import ACLService](#import-aclservice)
   * [Import ACL config](#import-acl-config)
   * [Checking roles and rules](#checking-roles-and-rules)
+    * [Usage example](#usage-example)
   * [Setup logging](#setup-logging-1)
   * [Public methods](#public-methods-1)
 * [Unit tests](#unit-tests)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
-ACL
+The ACL Package
 =============
 
-Access Control List Service
-
 * [Install](#install)
-* [How to](#how-to)
-  * [Define rules](#define-rules)
-  * [Create rules](#create-rules)
-  * [Import rules](#import-rules)
-  * [Setup logging](#setup-logging)
-* [Public methods](#public-methods)
+* [Usage options](#usage-options)
+* [ACLService](#aclservice)
+  * Define rules
+  * Create rules
+  * Import rules
+  * Setup logging
+  * Public methods
+* [ACLManager](#aclmanager)
+  * Import ACLService
+  * Import ACL config
+  * Checking roles and rules
+  * Setup logging
+  * Public methods
 * [Unit tests](#unit-tests)
+
+
 
 
 ## Install
@@ -19,7 +26,27 @@ Access Control List Service
 $ npm i @techteamer/acl --save
 ```
 
-## How to
+## Usage options
+
+After installing the package there are two ways you can use it.
+
+### Single ACL usage
+You can use a single ACLService instance to handle your rules and roles in a single list.
+
+### Multiple ACL usage
+You can use an ACLManager to handle multiple ACLService instances.
+In this case there is a priority between the ACLs added to the manager.
+The ACL which was added later takes precedence over the previously added ones.
+
+An other way of saying this is: you can override the ACLs by adding newer lists but
+if the role you are looking for cannot be found in the ACL with the highest priority
+the manager will fallback to the ACLs with lower priority.
+
+> **WARNING!** If the ACLManager found the role in the first ACL list it will not fallback to lower priority ACLs
+> even if the higher priority one do not have the rule you were looking for.
+
+
+## ACLService
 
 ### Define rules
 
@@ -216,9 +243,160 @@ Clear all results from result cache.
 
 Clear all roles, rules and results from ACL instance.
 
+## ACLManager
+
+### Import ACLService
+
+```js
+const { ACLManager, ACLService } = require('@techteamer/acl')
+
+// create ACL instance
+const acl = new ACLService()
+
+// import roles and rules to ACLService
+acl.import({
+  "admin":[
+    "users.*",
+    "system.*"
+  ],
+  "supervisor":[
+    "users.*",
+    "!users.delete",
+    "system.*",
+    "!system.shutdown",
+    "@ignored"
+  ],
+  "@ignored":[
+    "users.list"
+  ]
+})
+
+// Import ACLService to ACLManager:
+const acm = new ACLManager()
+acm.import(acl)
+
+// Use the ACLManager instead of the ACLService
+// returns true
+acm.isAllowed('users.create', 'supervisor')
+
+// returns false
+acm.isAllowed('users.delete', 'supervisor')
+```
+
+### Import ACL config
+
+```js
+const { ACLManager } = require('@techteamer/acl')
+
+// Import ACL config directly into the ACLManager:
+const acm = new ACLManager()
+acm.importConfig({
+  "admin":[
+    "users.*",
+    "system.*"
+  ],
+  "supervisor":[
+    "users.*",
+    "!users.delete",
+    "system.*",
+    "!system.shutdown",
+    "@ignored"
+  ],
+  "@ignored":[
+    "users.list"
+  ]
+})
+
+// Use the ACLManager instead of the ACLService
+// returns true
+acm.isAllowed('users.create', 'supervisor')
+
+// returns false
+acm.isAllowed('users.delete', 'supervisor')
+```
+### Checking roles and rules
+
+To check for roles and rules you can use the same methods:
+- `isAllowed(rule, role)`
+- `areAllowed(rules, role)`
+- `anyAllowed(rules, role)`
+
+#### Usage example:
+```js
+const { ACLManager } = require('@techteamer/acl')
+
+// Import ACL config directly into the ACLManager:
+const acm = new ACLManager()
+// Lower priority
+acm.importConfig({
+  "admin":[
+    // Any rule listed here will be ignored...
+    "system.shutdown"
+  ],
+  "supervisor":[
+    // Every 'supervisor' role check will fallback to this rule list:
+    "users.*",
+    "!users.delete"
+  ]
+})
+
+// Higher priority (added later)
+acm.importConfig({
+  "admin":[
+    // Rules here will take precedence over the ones listed in the first ACL config's 'admin' role section.
+    "users.*",
+  ]
+})
+
+// returns true
+acm.isAllowed('users.create', 'supervisor') // Fallback
+acm.isAllowed('users.delete', 'admin') // No fallback
+
+// returns false
+acm.isAllowed('users.delete', 'supervisor') // Fallback
+acm.isAllowed('system.shutdown', 'admin') // No fallback!!! Only rule in admin role is: 'users.*'
+
+```
+
+### Setup logging
+
+__Logging disabled by default!__
+
+> **NOTE:** The logger will be set to all managed ACLService instances as well!
+
+Single callback as logger
+
+```js
+acm.logger = function(level, message) {
+  // available log levels:
+  //  - debug: verbose process messages
+  //  - info: general informations
+  //  - warn: warning messages (not critical)
+  //  - error: error messages (critical)
+  ...
+}
+```
+
+Object (or any class instance) with public methods
+
+```js
+acm.logger = {
+  info: function(message){ ... },
+  warn: function(message){ ... },
+  ...
+}
+```
+
+## Public methods
+
+The ACL manager has the same API as the ACLService except these methods:
+- `createRole`
+- `createRule`
+- `clearResultCache`
+
 ## Unit tests
 
-To run the test suite, first install the dependencies, then run the test:
+To run the test suites, first install the dependencies, then run the tests:
 
 ```
 $ npm install

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ The ACL Package
 * [Install](#install)
 * [Usage options](#usage-options)
 * [ACLService](#aclservice)
-  * Define rules
-  * Create rules
-  * Import rules
-  * Setup logging
-  * Public methods
+  * [Define rules](#define-rules)
+  * [Create rules](#create-rules)
+  * [Import rules](#import-rules)
+  * [Setup logging](#setup-logging)
+  * [Public methods](#public-methods)
 * [ACLManager](#aclmanager)
-  * Import ACLService
-  * Import ACL config
-  * Checking roles and rules
-  * Setup logging
-  * Public methods
+  * [Import ACLService](#import-aclservice)
+  * [Import ACL config](#import-acl-config)
+  * [Checking roles and rules](#checking-roles-and-rules)
+  * [Setup logging](#setup-logging-1)
+  * [Public methods](#public-methods-1)
 * [Unit tests](#unit-tests)
 
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   ACLService: require('./src/ACLService'),
-  ACLError: require('./src/ACLError')
+  ACLError: require('./src/ACLError'),
+  ACLManager: require('./src/ACLManager')
 }

--- a/src/ACLManager.js
+++ b/src/ACLManager.js
@@ -89,10 +89,6 @@ class ACLManager {
   }
 
   clear () {
-    for (const acl of this.aclList) {
-      acl.clear()
-    }
-
     this.aclList = []
   }
 

--- a/src/ACLManager.js
+++ b/src/ACLManager.js
@@ -55,7 +55,7 @@ class ACLManager {
       }
     }
 
-    return false
+    return null
   }
 
   isAllowed (access, role) {

--- a/src/ACLManager.js
+++ b/src/ACLManager.js
@@ -88,6 +88,14 @@ class ACLManager {
     return acl.anyAllowed(accessList, role)
   }
 
+  clear () {
+    for (const acl of this.aclList) {
+      acl.clear()
+    }
+
+    this.aclList = []
+  }
+
   _log (level, message) {
     if (this.log instanceof Object && this.log[level] instanceof Function) {
       this.log[level](message)

--- a/src/ACLManager.js
+++ b/src/ACLManager.js
@@ -1,0 +1,100 @@
+const ACLError = require('./ACLError')
+const ACLService = require('./ACLService')
+
+class ACLManager {
+  constructor () {
+    this.log = false
+    this.aclList = []
+  }
+
+  set logger (value) {
+    this.log = value
+
+    for (const acl of this.aclList) {
+      acl.logger = this.log
+    }
+  }
+
+  get logger () {
+    return this.log
+  }
+
+  importConfig (configJSON) {
+    const acl = new ACLService()
+    acl.import(configJSON)
+
+    if (this.log) {
+      acl.logger = this.log
+    }
+
+    this.import(acl)
+  }
+
+  import (acl) {
+    if (!(acl instanceof ACLService)) {
+      this._log('error', 'Failed to import non-ACL value')
+    }
+
+    // The latest ACL takes precedence
+    this.aclList.unshift(acl)
+  }
+
+  get roleList () {
+    // Flattened unique role list array across every acl
+    return Array.from(new Set([].concat(...this.aclList.map(acl => acl.roleList))))
+  }
+
+  getACLForRole (role) {
+    for (let acl of this.aclList) {
+      if (acl.roleList.includes(role)) {
+        return acl
+      }
+    }
+
+    return false
+  }
+
+  isAllowed (access, role) {
+    const acl = this.getACLForRole(role)
+    if (!acl) {
+      this._log('warn', `Role not found: '${role}' in any ACL`)
+      return false
+    }
+
+    return acl.isAllowed(access, role)
+  }
+
+  areAllowed (accessList, role) {
+    const acl = this.getACLForRole(role)
+    if (!acl) {
+      this._log('warn', `Role not found: '${role}' in any ACL`)
+      return false
+    }
+
+    return acl.areAllowed(accessList, role)
+  }
+
+  anyAllowed (accessList, role) {
+    const acl = this.getACLForRole(role)
+    if (!acl) {
+      this._log('warn', `Role not found: '${role}' in any ACL`)
+      return false
+    }
+
+    return acl.anyAllowed(accessList, role)
+  }
+
+  _log (level, message) {
+    if (this.log instanceof Object && this.log[level] instanceof Function) {
+      this.log[level](message)
+    } else if (this.log instanceof Function) {
+      this.log(level, message)
+    }
+
+    if (level === 'error') {
+      throw new ACLError(message)
+    }
+  }
+}
+
+module.exports = ACLManager

--- a/src/ACLManager.js
+++ b/src/ACLManager.js
@@ -44,6 +44,10 @@ class ACLManager {
     return Array.from(new Set([].concat(...this.aclList.map(acl => acl.roleList))))
   }
 
+  hasRole (role) {
+    return this.roleList.includes(role)
+  }
+
   getACLForRole (role) {
     for (let acl of this.aclList) {
       if (acl.roleList.includes(role)) {

--- a/test/ACLManager.test.js
+++ b/test/ACLManager.test.js
@@ -155,3 +155,10 @@ describe('ACLManager.anyAllowed', function () {
     assert.ok(!acm.anyAllowed([], 'admin'))
   })
 })
+
+describe('ACLManager.clear', function () {
+  it('Clears ACL instances from manager', function () {
+    acm.clear()
+    assert.ok(acm.aclList.length === 0)
+  })
+})

--- a/test/ACLManager.test.js
+++ b/test/ACLManager.test.js
@@ -98,7 +98,7 @@ describe('ACLManager.getACLForRole', function () {
     assert.ok(acm.getACLForRole('supervisor') === acl1)
   })
   it('Returns false if the role is missing', function () {
-    assert.ok(acm.getACLForRole('missingRole') === false)
+    assert.ok(acm.getACLForRole('missingRole') === null)
   })
 })
 

--- a/test/ACLManager.test.js
+++ b/test/ACLManager.test.js
@@ -78,6 +78,15 @@ describe('ACLManager.roleList', function () {
   })
 })
 
+describe('ACL.hasRole', function () {
+  it('Positive result when role exists: \'admin\'', function () {
+    assert.ok(acm.hasRole('admin'))
+  })
+  it('Negative result when role not exists: \'missingRole\'', function () {
+    assert.ok(!acm.hasRole('missingRole'))
+  })
+})
+
 describe('ACLManager.getACLForRole', function () {
   it('Finds existing role', function () {
     assert.ok(acm.getACLForRole('admin') instanceof ACLService)

--- a/test/ACLManager.test.js
+++ b/test/ACLManager.test.js
@@ -1,0 +1,148 @@
+const assert = require('assert')
+const { ACLManager, ACLService } = require('./../index')
+const acl1 = new ACLService()
+const acl2 = new ACLService()
+let acm
+
+// Lowest ACL level
+const acl0Config = {
+  "admin": [ // We will never get here
+    "*"
+  ],
+  "operator": [  // Falls back here from acl2 then acl1
+    "calls.accept"
+  ]
+}
+
+// Lower precedence ACL
+acl1.import({
+  "admin": [ // We will never get here
+    "users.*",
+    "system.*"
+  ],
+  "supervisor": [ // Falls back here from acl2
+    "users.*",
+    "!users.delete",
+    "system.*",
+    "!system.shutdown",
+    "@ignored"
+  ]
+})
+
+// Higher precedence ACL
+acl2.import({
+  "admin": [
+    "users.*",
+  ]
+})
+
+describe('ACLManager.constructor', function () {
+  it('Can construct a new ACLManager', function () {
+    acm = new ACLManager()
+  })
+})
+
+describe('ACLManager.importConfig', function () {
+  it('Import ACL config', function () {
+    assert.doesNotThrow(function () {
+      acm.importConfig(acl0Config)
+    })
+  })
+})
+
+describe('ACLManager.import', function () {
+  it('Import multiple ACLs', function () {
+    assert.doesNotThrow(function () {
+      acm.import(acl1)
+    })
+    assert.doesNotThrow(function () {
+      acm.import(acl2)
+    })
+  })
+  it('Throws an Error when trying to import a Non-ACL object', function () {
+    assert.throws(function () {
+      acm.import({
+        thisIsAnACL: false
+      })
+    })
+  })
+})
+
+describe('ACLManager.roleList', function () {
+  it('Can list every role across all ACL', function () {
+    assert.ok(Array.isArray(acm.roleList))
+    assert.ok(acm.roleList.includes('admin'))
+    assert.ok(acm.roleList.includes('supervisor'))
+    assert.ok(acm.roleList.includes('operator'))
+    assert.ok(!acm.roleList.includes('missingRole'))
+  })
+})
+
+describe('ACLManager.getACLForRole', function () {
+  it('Finds existing role', function () {
+    assert.ok(acm.getACLForRole('admin') instanceof ACLService)
+  })
+  it('Finds the role in the ACL with the higher precedence first', function () {
+    assert.ok(acm.getACLForRole('admin') === acl2)
+  })
+  it('Falls back to lower precedence ACLs when the role is not present in the ACL with the higher precedence', function () {
+    assert.ok(acm.getACLForRole('supervisor') === acl1)
+  })
+  it('Returns false if the role is missing', function () {
+    assert.ok(acm.getACLForRole('missingRole') === false)
+  })
+})
+
+describe('ACLManager.isAllowed', function () {
+  it('Higher precedence ACL returns true for existing rules', function () {
+    assert.ok(acm.isAllowed('users.delete', 'admin'))
+  })
+  it('Higher precedence ACL returns false for missing rules (and does not fallback to lower precedence ACL)', function () {
+    assert.ok(!acm.isAllowed('system.shutdown', 'admin'))
+  })
+  it('Lower precedence ACL returns true when role is missing from higher precedence ACL', function () {
+    assert.ok(acm.isAllowed('system.start', 'supervisor'))
+  })
+  it('Lower precedence ACL returns false when role is missing from higher precedence ACL', function () {
+    assert.ok(!acm.isAllowed('system.shutdown', 'supervisor'))
+  })
+  it('Returns false if the role is missing', function () {
+    assert.ok(!acm.isAllowed('system.shutdown', 'missingRole'))
+  })
+})
+
+describe('ACLManager.areAllowed', function () {
+  it('Positive result for higher ACL', function () {
+    assert.ok(acm.areAllowed(['users.delete', 'users.modify'], 'admin'))
+  })
+  it('Negative result for higher ACL', function () {
+    assert.ok(!acm.areAllowed(['system.shutdown'], 'admin'))
+  })
+  it('Positive result for lower ACL', function () {
+    assert.ok(acm.areAllowed(['users.create', 'users.modify'], 'supervisor'))
+  })
+  it('Negative result for lower ACL', function () {
+    assert.ok(!acm.areAllowed(['users.delete', 'system.shutdown'], 'supervisor'))
+  })
+  it('Negative result on empty list', function () {
+    assert.ok(!acm.areAllowed([], 'admin'))
+  })
+})
+
+describe('ACLManager.anyAllowed', function () {
+  it('Positive result for higher ACL', function () {
+    assert.ok(acm.anyAllowed(['users.delete', 'system.shutdown'], 'admin'))
+  })
+  it('Negative result for higher ACL', function () {
+    assert.ok(!acm.anyAllowed(['system.shutdown'], 'admin'))
+  })
+  it('Positive result for lower ACL', function () {
+    assert.ok(acm.anyAllowed(['users.create', 'system.shutdown'], 'supervisor'))
+  })
+  it('Negative result for lower ACL', function () {
+    assert.ok(!acm.anyAllowed(['users.delete', 'system.shutdown'], 'supervisor'))
+  })
+  it('Negative result on empty list', function () {
+    assert.ok(!acm.anyAllowed([], 'admin'))
+  })
+})


### PR DESCRIPTION
Added `ACLManager` class to manage multiple ACLs at once.
The API is very similar to the `ACLService`'s API.

> Check out the new README.md for usage examples and documentation.