### PR TITLE
Duplicate rule config thorws error

### DIFF
--- a/src/ACLService.js
+++ b/src/ACLService.js
@@ -19,16 +19,10 @@ class ACLService {
         this.createRole(role)
       }
 
-      const rules = [...new Set(configJSON[role].sort())]
-      if (rules.length !== configJSON[role].length) {
-        let duplicates = [...configJSON[role]]
-        rules.forEach(item => {
-          const i = duplicates.indexOf(item)
-          duplicates = duplicates
-            .slice(0, i)
-            .concat(duplicates.slice(i + 1, duplicates.length))
-        })
+      const rules = configJSON[role]
+      const duplicates = rules.filter((item, index) => rules.indexOf(item) !== index)
 
+      if (duplicates.length > 0) {
         this._log('error', `Role '${role}' has duplicate rules: ${duplicates}`)
       }
 

--- a/src/ACLService.js
+++ b/src/ACLService.js
@@ -18,7 +18,21 @@ class ACLService {
       if (!this.hasRole(role)) {
         this.createRole(role)
       }
-      for (let rule of configJSON[role].sort()) {
+
+      const rules = [...new Set(configJSON[role].sort())]
+      if (rules.length !== configJSON[role].length) {
+        let duplicates = [...configJSON[role]]
+        rules.forEach(item => {
+          const i = duplicates.indexOf(item)
+          duplicates = duplicates
+            .slice(0, i)
+            .concat(duplicates.slice(i + 1, duplicates.length))
+        })
+
+        this._log('error', `Role '${role}' has duplicate rules: ${duplicates}`)
+      }
+
+      for (let rule of rules) {
         if (rule[0] === '@') {
           this._log('warn', `Rule ignored: ${role}\\${rule.substr(1)}`)
           continue

--- a/test/ACLService.test.js
+++ b/test/ACLService.test.js
@@ -114,7 +114,9 @@ describe('ACL.import', function () {
     }(), 'Created rule not found as a regular expression')
   })
   it('Import throw error on duplicate rules', function () {
+    assert.throws(function () {
       ACL.import({"supervisor": ["users.create", "users.secret", "users.create"]})
+    })
   })
 })
 

--- a/test/ACLService.test.js
+++ b/test/ACLService.test.js
@@ -113,6 +113,9 @@ describe('ACL.import', function () {
       }
     }(), 'Created rule not found as a regular expression')
   })
+  it('Import throw error on duplicate rules', function () {
+      ACL.import({"supervisor": ["users.create", "users.secret", "users.create"]})
+  })
 })
 
 describe('ACL.isAllowed', function () {


### PR DESCRIPTION
Throws error if a *role* has duplicate *rules*.
This also fixes some issues. Duplicate rules previously cased errors because they cleared the every other rule from the role.